### PR TITLE
Clarify @return in use_rstudio_prefs.R

### DIFF
--- a/R/use_rstudio_prefs.R
+++ b/R/use_rstudio_prefs.R
@@ -9,7 +9,7 @@
 #' `always_save_history = FALSE, rainbow_parentheses = TRUE`
 #'
 #' @export
-#' @return NULL, updates RStudio `rstudio-prefs.json` file
+#' @return updates RStudio `rstudio-prefs.json` file and returns a list of the updated preferences or NULL if there are none.
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()


### PR DESCRIPTION
This is a tiny PR to clarify that you can use `use_rstudio_prefs()` as a getter in some cases.