### PR TITLE
Fix @return documentation and redocument with roxygen2 8.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+Config/roxygen2/version: 8.0.0

--- a/R/use_rstudio_keyboard_shortcut.R
+++ b/R/use_rstudio_keyboard_shortcut.R
@@ -14,7 +14,10 @@
 #' file before it's updated. Default is `TRUE`
 #'
 #' @export
-#' @return NULL, updates RStudio `addins.json` file
+#' @return updates RStudio `addins.json` file and returns a list of the
+#'   updated keyboard shortcuts or NULL if there are none. When
+#'   `.write_json = FALSE`, returns the full list of all keyboard shortcuts
+#'   without writing to file.
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()

--- a/R/use_rstudio_prefs.R
+++ b/R/use_rstudio_prefs.R
@@ -9,7 +9,9 @@
 #' `always_save_history = FALSE, rainbow_parentheses = TRUE`
 #'
 #' @export
-#' @return NULL, updates RStudio `rstudio-prefs.json` file
+#' @return updates RStudio `rstudio-prefs.json` file and returns a list of the
+#'   updated preferences or NULL if there are none. When `.write_json = FALSE`,
+#'   returns the full list of all preferences without writing to file.
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()

--- a/R/use_rstudio_secondary_repo.R
+++ b/R/use_rstudio_secondary_repo.R
@@ -2,7 +2,7 @@
 #'
 #' This function updates the RStudio preferences saved in
 #' the `rstudio-prefs.json` file to include the secondary repositories
-#' passed my the user. If a new name for an existing repository is
+#' passed by the user. If a new name for an existing repository is
 #' passed by the user, the name will be updated in the JSON file.
 #'
 #' A note for users outside of the USA.
@@ -14,7 +14,8 @@
 #' `ropensci = "https://ropensci.r-universe.dev"`
 #'
 #' @export
-#' @return NULL, updates RStudio `rstudio-prefs.json` file
+#' @return updates RStudio `rstudio-prefs.json` file and returns a list of the
+#'   updated secondary repositories or NULL if there are none.
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()

--- a/man/make_path_norm.Rd
+++ b/man/make_path_norm.Rd
@@ -10,7 +10,7 @@ make_path_norm()
 normalized path string
 }
 \description{
-Wrapper to execute \code{\link[fs:path_math]{fs::path_norm()}} as a shortcut on
+Wrapper to execute \code{\link[fs:path_norm]{fs::path_norm()}} as a shortcut on
 highlighted text. The updated text will be converted in place to a path
 normalized for the environment currently in use.
 For instance, \ or \\\ will be converted to / on Windows machines.
@@ -38,5 +38,5 @@ if (interactive()) {
 }
 }
 \seealso{
-\link[fs:path_math]{fs::path_norm}
+\link[fs:path_norm]{fs::path_norm}
 }

--- a/man/use_rstudio_keyboard_shortcut.Rd
+++ b/man/use_rstudio_keyboard_shortcut.Rd
@@ -20,14 +20,17 @@ them to file.}
 file before it's updated. Default is \code{TRUE}}
 }
 \value{
-NULL, updates RStudio \code{addins.json} file
+updates RStudio \code{addins.json} file and returns a list of the
+updated keyboard shortcuts or NULL if there are none. When
+\code{.write_json = FALSE}, returns the full list of all keyboard shortcuts
+without writing to file.
 }
 \description{
 This function updates the RStudio keyboard shortcuts saved in
 the \code{addins.json} file.
 }
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 use_rstudio_keyboard_shortcut(
   "Ctrl+Shift+/" = "rstudio.prefs::make_path_norm"
 )

--- a/man/use_rstudio_prefs.Rd
+++ b/man/use_rstudio_prefs.Rd
@@ -11,7 +11,9 @@ use_rstudio_prefs(...)
 \verb{always_save_history = FALSE, rainbow_parentheses = TRUE}}
 }
 \value{
-NULL, updates RStudio \code{rstudio-prefs.json} file
+updates RStudio \code{rstudio-prefs.json} file and returns a list of the
+updated preferences or NULL if there are none. When \code{.write_json = FALSE},
+returns the full list of all preferences without writing to file.
 }
 \description{
 This function updates the RStudio preferences saved in
@@ -20,7 +22,7 @@ modified are listed here
 \url{https://docs.rstudio.com/ide/server-pro/session-user-settings.html}
 }
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 # pass preferences individually --------------
 use_rstudio_prefs(
   always_save_history = FALSE,

--- a/man/use_rstudio_secondary_repo.Rd
+++ b/man/use_rstudio_secondary_repo.Rd
@@ -11,12 +11,13 @@ use_rstudio_secondary_repo(...)
 \code{ropensci = "https://ropensci.r-universe.dev"}}
 }
 \value{
-NULL, updates RStudio \code{rstudio-prefs.json} file
+updates RStudio \code{rstudio-prefs.json} file and returns a list of the
+updated secondary repositories or NULL if there are none.
 }
 \description{
 This function updates the RStudio preferences saved in
 the \code{rstudio-prefs.json} file to include the secondary repositories
-passed my the user. If a new name for an existing repository is
+passed by the user. If a new name for an existing repository is
 passed by the user, the name will be updated in the JSON file.
 }
 \details{
@@ -26,7 +27,7 @@ in the JSON preferences file (typically, auto set by RStudio),
 the \code{use_rstudio_secondary_repo()} function will set \code{"country" = "us"}.
 }
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 use_rstudio_secondary_repo(
   ropensci = "https://ropensci.r-universe.dev",
   ddsjoberg = "https://ddsjoberg.r-universe.dev"


### PR DESCRIPTION
This PR supersedes #19 (by @DanChaltiel) and addresses both follow-up requests made by @ddsjoberg on May 15, 2023:

1. Redocument the package and include updated `.Rd` files
2. Update `@return` for `use_rstudio_keyboard_shortcut()` and `use_rstudio_secondary_repo()`

Changes:
- `use_rstudio_prefs()`: documents actual return value including getter behaviour when `.write_json = FALSE`
- `use_rstudio_keyboard_shortcut()`: same pattern, including `.write_json = FALSE` getter behaviour
- `use_rstudio_secondary_repo()`: documents actual return value; fixes typo "passed my the user" → "passed by the user"
- `DESCRIPTION`: bumped `RoxygenNote` to 8.0.0
- `man/make_path_norm.Rd`: incidental fix of broken cross-reference link (`path_math` → `path_norm`) surfaced by roxygen2 8.0.0