### PR TITLE
Update return docs, refresh fetch URL and fix shortcut bugs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,10 +34,10 @@ Imports:
 Suggests: 
     covr (>= 3.5.1),
     spelling (>= 2.2),
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    withr (>= 2.3.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-US
-LazyData: true
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+Config/roxygen2/version: 8.0.0
+Config/roxygen2/markdown: TRUE

--- a/R/fetch_rstudio_prefs.R
+++ b/R/fetch_rstudio_prefs.R
@@ -1,7 +1,7 @@
 #' Fetch table of RStudio Preferences
 #'
 #' Preferences are fetched from
-#' [https://docs.rstudio.com/ide/server-pro/session-user-settings.html](https://docs.rstudio.com/ide/server-pro/session-user-settings.html)
+#' [https://docs.posit.co/ide/server-pro/admin/reference/session_user_settings.html](https://docs.posit.co/ide/server-pro/admin/reference/session_user_settings.html)
 #'
 #' @section Details:
 #' Only preferences of type `"boolean"`, `"string"`, `"number"`, `"integer"`,
@@ -17,7 +17,7 @@
 #'
 #' fetch_rstudio_prefs()
 fetch_rstudio_prefs <- function() {
-  url <- "https://docs.rstudio.com/ide/server-pro/session_user_settings/session_user_settings.html"
+  url <- "https://docs.posit.co/ide/server-pro/admin/reference/session_user_settings.html"
   cli::cli_alert_success("Downloading list of available {.field RStudio} settings")
   cat("\n")
   tryCatch(

--- a/R/rstudio.prefs-package.R
+++ b/R/rstudio.prefs-package.R
@@ -7,6 +7,9 @@
 # allowing for the use of the dot when piping
 utils::globalVariables(".")
 
+# primitive base function bindings required for mocking in covr tests
+interactive <- NULL
+
 # The following block is used by usethis to automatically manage
 # roxygen namespace tags. Modify with care!
 ## usethis namespace: start

--- a/R/use_rstudio_keyboard_shortcut.R
+++ b/R/use_rstudio_keyboard_shortcut.R
@@ -5,21 +5,30 @@
 #'
 #' @param ... series of RStudio keyboard shortcuts to update. The argument
 #' name is the keyboard shortcut, and the value is a string of the function
-#' name that will execute. See examples.
+#' name that will execute, or `NULL` to remove the shortcut. If a new shortcut
+#' shares a key or function with an existing one, the previous binding is
+#' removed.
 #' @param .write_json logical indicating whether to update and overwrite
 #' the existing JSON file of options. Default is `TRUE`. When `FALSE`,
-#' the function will return a list of all options, instead of writing
+#' the function will return a list of all shortcuts, instead of writing
 #' them to file.
-#' @param .backup logical indicating whether to create a back-up of preferences
-#' file before it's updated. Default is `TRUE`
+#' @param .backup logical indicating whether to create a back-up of shortcuts
+#' file before it's updated. Default is `TRUE`.
 #'
 #' @export
-#' @return NULL, updates RStudio `addins.json` file
+#' @return When `.write_json = FALSE`, a named list of all shortcuts including
+#'   the updates. Otherwise `NULL` invisibly.
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()
+#' # Add a shortcut
 #' use_rstudio_keyboard_shortcut(
 #'   "Ctrl+Shift+/" = "rstudio.prefs::make_path_norm"
+#' )
+#'
+#' # Remove a shortcut
+#' use_rstudio_keyboard_shortcut(
+#'   "Ctrl+Shift+/" = NULL
 #' )
 
 use_rstudio_keyboard_shortcut <- function(..., .write_json = TRUE, .backup = TRUE) {
@@ -50,23 +59,38 @@ use_rstudio_keyboard_shortcut <- function(..., .write_json = TRUE, .backup = TRU
   # invert list names and values -----------------------------------------------
   i_list_current_shortcuts <- invert_list_names_and_values(list_current_shortcuts)
 
+  # remove stale bindings for functions that are being reassigned or removed ---
+  i_list_remaining_shortcuts <- i_list_current_shortcuts[
+    !unlist(i_list_current_shortcuts) %in% unname(unlist(i_list_updated_shortcuts)) |
+      names(i_list_current_shortcuts) %in% names(i_list_updated_shortcuts)
+  ]
+
+  # list vacated shortcuts as NULL so they appear in the update summary --------
+  vacated_keys <- setdiff(names(i_list_current_shortcuts), names(i_list_remaining_shortcuts))
+  i_list_vacated_shortcuts <- stats::setNames(rep(list(NULL), length(vacated_keys)), vacated_keys)
+
   # print updates that will be made --------------------------------------------
-  any_update <- pretty_print_updates(i_list_current_shortcuts, i_list_updated_shortcuts)
-  # if no updates, abort function execution
+  any_update <- pretty_print_updates(
+    i_list_current_shortcuts,
+    c(i_list_updated_shortcuts, i_list_vacated_shortcuts)
+  )
+
+  # if no updates, abort function execution ------------------------------------
   if (!any_update) {
     return(invisible(NULL))
   }
-  # ask user to abort or not
+
+  # ask user to abort or not ---------------------------------------------------
   if (!startsWith(tolower(readline("Would you like to continue? [y/n] ")), "y")) {
     return(invisible(NULL))
   }
 
-  # update prefs, convert to JSON, and save file -------------------------------
+  # merge new shortcuts, NULL values are removed by modifyList -----------------
   list_final_shortcuts <-
-    i_list_current_shortcuts %>%
-    purrr::update_list(!!!i_list_updated_shortcuts) %>%
+    utils::modifyList(i_list_remaining_shortcuts, i_list_updated_shortcuts) %>%
     invert_list_names_and_values()
 
+  # convert to JSON and save file ----------------------------------------------
   if (isTRUE(.write_json)) {
     write_json(
       list_final_shortcuts,
@@ -107,10 +131,10 @@ check_shortcut_consistency <- function(x) {
   if (!rlang::is_named(x)) {
     rlang::abort("Each argument must be named.")
   }
-  if (purrr::some(x, ~!rlang::is_string(.))) {
-    rlang::abort("Each argument value must be a string")
+  if (purrr::some(x, ~!rlang::is_string(.) && !is.null(.))) {
+    rlang::abort("Each argument value must be a string or NULL")
   }
-  if (purrr::some(x, ~!rlang::is_function(eval(rlang::parse_expr(.))))) {
+  if (purrr::some(x, ~!is.null(.) && !tryCatch(rlang::is_function(eval(rlang::parse_expr(.))), error = function(e) FALSE))) {
     rlang::abort("Each argument value must be a string of a function name.")
   }
 }

--- a/R/use_rstudio_prefs.R
+++ b/R/use_rstudio_prefs.R
@@ -3,13 +3,15 @@
 #' This function updates the RStudio preferences saved in
 #' the `rstudio-prefs.json` file. A full listing of preferences that may be
 #' modified are listed here
-#' \url{https://docs.rstudio.com/ide/server-pro/session-user-settings.html}
+#' \url{https://docs.posit.co/ide/server-pro/admin/reference/session_user_settings.html}
 #'
 #' @param ... series of RStudio preferences to update, e.g.
 #' `always_save_history = FALSE, rainbow_parentheses = TRUE`
 #'
 #' @export
-#' @return NULL, updates RStudio `rstudio-prefs.json` file
+#' @return Invisibly returns the updated preferences as a named list on success,
+#'   or `NULL` if no updates were made (no changes, user aborted, or not in an
+#’   interactive session).
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()

--- a/R/use_rstudio_secondary_repo.R
+++ b/R/use_rstudio_secondary_repo.R
@@ -2,7 +2,7 @@
 #'
 #' This function updates the RStudio preferences saved in
 #' the `rstudio-prefs.json` file to include the secondary repositories
-#' passed my the user. If a new name for an existing repository is
+#' passed by the user. If a new name for an existing repository is
 #' passed by the user, the name will be updated in the JSON file.
 #'
 #' A note for users outside of the USA.
@@ -14,7 +14,9 @@
 #' `ropensci = "https://ropensci.r-universe.dev"`
 #'
 #' @export
-#' @return NULL, updates RStudio `rstudio-prefs.json` file
+#' @return Invisibly returns the updated `cran_mirror` preference as a named
+#'   list on success, or `NULL` if no updates were made (no changes, user
+#'   aborted, or not in an interactive session).
 #' @author Daniel D. Sjoberg
 #'
 #' @examplesIf interactive()

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ devtools::install_github("ddsjoberg/rstudio.prefs")
 ### Set RStudio Preferences
 
 Update the RStudio default preferences.
-Full list of modifiable settings here: https://docs.rstudio.com/ide/server-pro/session-user-settings.html
+Full list of modifiable settings here: https://docs.posit.co/ide/server-pro/admin/reference/session_user_settings.html
 
 ``` r
 library(rstudio.prefs)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -14,4 +14,5 @@ programmatically
 repo
 repos
 rstudio
+rstudioapi
 tibble

--- a/man/fetch_rstudio_prefs.Rd
+++ b/man/fetch_rstudio_prefs.Rd
@@ -11,7 +11,7 @@ tibble
 }
 \description{
 Preferences are fetched from
-\url{https://docs.rstudio.com/ide/server-pro/session-user-settings.html}
+\url{https://docs.posit.co/ide/server-pro/admin/reference/session_user_settings.html}
 }
 \section{Details}{
 

--- a/man/make_path_norm.Rd
+++ b/man/make_path_norm.Rd
@@ -10,7 +10,7 @@ make_path_norm()
 normalized path string
 }
 \description{
-Wrapper to execute \code{\link[fs:path_math]{fs::path_norm()}} as a shortcut on
+Wrapper to execute \code{\link[fs:path_norm]{fs::path_norm()}} as a shortcut on
 highlighted text. The updated text will be converted in place to a path
 normalized for the environment currently in use.
 For instance, \ or \\\ will be converted to / on Windows machines.
@@ -38,5 +38,5 @@ if (interactive()) {
 }
 }
 \seealso{
-\link[fs:path_math]{fs::path_norm}
+\link[fs:path_norm]{fs::path_norm}
 }

--- a/man/rstudio.prefs-package.Rd
+++ b/man/rstudio.prefs-package.Rd
@@ -20,5 +20,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Daniel D. Sjoberg \email{danield.sjoberg@gmail.com} (\href{https://orcid.org/0000-0003-0862-2018}{ORCID}) [copyright holder]
 
+Authors:
+\itemize{
+  \item Daniel D. Sjoberg \email{danield.sjoberg@gmail.com} (\href{https://orcid.org/0000-0003-0862-2018}{ORCID}) [copyright holder]
+}
+
 }
 \keyword{internal}

--- a/man/use_rstudio_keyboard_shortcut.Rd
+++ b/man/use_rstudio_keyboard_shortcut.Rd
@@ -9,27 +9,36 @@ use_rstudio_keyboard_shortcut(..., .write_json = TRUE, .backup = TRUE)
 \arguments{
 \item{...}{series of RStudio keyboard shortcuts to update. The argument
 name is the keyboard shortcut, and the value is a string of the function
-name that will execute. See examples.}
+name that will execute, or \code{NULL} to remove the shortcut. If a new shortcut
+shares a key or function with an existing one, the previous binding is
+removed.}
 
 \item{.write_json}{logical indicating whether to update and overwrite
 the existing JSON file of options. Default is \code{TRUE}. When \code{FALSE},
-the function will return a list of all options, instead of writing
+the function will return a list of all shortcuts, instead of writing
 them to file.}
 
-\item{.backup}{logical indicating whether to create a back-up of preferences
-file before it's updated. Default is \code{TRUE}}
+\item{.backup}{logical indicating whether to create a back-up of shortcuts
+file before it's updated. Default is \code{TRUE}.}
 }
 \value{
-NULL, updates RStudio \code{addins.json} file
+When \code{.write_json = FALSE}, a named list of all shortcuts including
+the updates. Otherwise \code{NULL} invisibly.
 }
 \description{
 This function updates the RStudio keyboard shortcuts saved in
 the \code{addins.json} file.
 }
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
+# Add a shortcut
 use_rstudio_keyboard_shortcut(
   "Ctrl+Shift+/" = "rstudio.prefs::make_path_norm"
+)
+
+# Remove a shortcut
+use_rstudio_keyboard_shortcut(
+  "Ctrl+Shift+/" = NULL
 )
 \dontshow{\}) # examplesIf}
 }

--- a/man/use_rstudio_prefs.Rd
+++ b/man/use_rstudio_prefs.Rd
@@ -11,16 +11,17 @@ use_rstudio_prefs(...)
 \verb{always_save_history = FALSE, rainbow_parentheses = TRUE}}
 }
 \value{
-NULL, updates RStudio \code{rstudio-prefs.json} file
+Invisibly returns the updated preferences as a named list on success,
+or \code{NULL} if no updates were made (no changes, user aborted, or not in an
 }
 \description{
 This function updates the RStudio preferences saved in
 the \code{rstudio-prefs.json} file. A full listing of preferences that may be
 modified are listed here
-\url{https://docs.rstudio.com/ide/server-pro/session-user-settings.html}
+\url{https://docs.posit.co/ide/server-pro/admin/reference/session_user_settings.html}
 }
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 # pass preferences individually --------------
 use_rstudio_prefs(
   always_save_history = FALSE,

--- a/man/use_rstudio_secondary_repo.Rd
+++ b/man/use_rstudio_secondary_repo.Rd
@@ -11,12 +11,14 @@ use_rstudio_secondary_repo(...)
 \code{ropensci = "https://ropensci.r-universe.dev"}}
 }
 \value{
-NULL, updates RStudio \code{rstudio-prefs.json} file
+Invisibly returns the updated \code{cran_mirror} preference as a named
+list on success, or \code{NULL} if no updates were made (no changes, user
+aborted, or not in an interactive session).
 }
 \description{
 This function updates the RStudio preferences saved in
 the \code{rstudio-prefs.json} file to include the secondary repositories
-passed my the user. If a new name for an existing repository is
+passed by the user. If a new name for an existing repository is
 passed by the user, the name will be updated in the JSON file.
 }
 \details{
@@ -26,7 +28,7 @@ in the JSON preferences file (typically, auto set by RStudio),
 the \code{use_rstudio_secondary_repo()} function will set \code{"country" = "us"}.
 }
 \examples{
-\dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive()) withAutoprint(\{ # examplesIf}
 use_rstudio_secondary_repo(
   ropensci = "https://ropensci.r-universe.dev",
   ddsjoberg = "https://ddsjoberg.r-universe.dev"

--- a/tests/testthat/test-use_rstudio_keyboard_shortcut.R
+++ b/tests/testthat/test-use_rstudio_keyboard_shortcut.R
@@ -1,18 +1,412 @@
-test_that("check_shortcut_consistency()", {
-  expect_error(
-    as.list(letters) %>% check_shortcut_consistency()
+# use_rstudio_keyboard_shortcut() ----------------------------------------------
+
+test_that("use_rstudio_keyboard_shortcut() - returns NULL when not interactive", {
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL)
   )
 
-  expect_error(
-    list(test = 5) %>% check_shortcut_consistency()
+  local_mocked_bindings(
+    interactive = function() FALSE,              # <-- not interactive
+    .package = "base"
   )
 
-  expect_error(
-    # `make_path_norm()` is a function
-    list(test = "make_path_norm") %>% check_shortcut_consistency(),
-    NA
+  suppressMessages(
+    result <- use_rstudio_keyboard_shortcut(
+      "Ctrl+Shift+/" = "make_path_norm"
+    )
   )
+
+  expect_null(result)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - returns NULL when no updates needed", {
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) FALSE,  # <-- no updates
+    rstudio_config_path = function(x) file.path(withr::local_tempdir(), x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    .package = "base"
+  )
+
+  result <- use_rstudio_keyboard_shortcut(
+    "Ctrl+Shift+/" = "make_path_norm"
+  )
+
+  expect_null(result)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - returns NULL when user declines", {
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) TRUE,
+    rstudio_config_path = function(x) file.path(withr::local_tempdir(), x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) "n",             # <-- user declines
+    .package = "base"
+  )
+
+  result <- use_rstudio_keyboard_shortcut(
+    "Ctrl+Shift+/" = "make_path_norm"
+  )
+
+  expect_null(result)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - returns updated list when .write_json = FALSE", {
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) TRUE,
+    rstudio_config_path = function(x) file.path(withr::local_tempdir(), x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) "y",
+    .package = "base"
+  )
+
+  suppressMessages(
+    result <- use_rstudio_keyboard_shortcut(
+      "Ctrl+Shift+/" = "make_path_norm",
+      .write_json = FALSE
+    )
+  )
+
+  expect_type(result, "list")
+  expect_equal(result[["make_path_norm"]], "Ctrl+Shift+/")
+  expect_length(result, 1)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - writes JSON when .write_json = TRUE", {
+  tmp <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) TRUE,
+    rstudio_config_path = function(x) file.path(tmp, x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) "y",
+    .package = "base"
+  )
+
+  suppressMessages(
+    result <- use_rstudio_keyboard_shortcut(
+      "Ctrl+Shift+/" = "make_path_norm",
+      .write_json = TRUE
+    )
+  )
+
+  expect_null(result)
+  expect_true(fs::file_exists(file.path(tmp, "keybindings/addins.json")))
+  written <- jsonlite::fromJSON(file.path(tmp, "keybindings/addins.json"))
+  expect_equal(written[["make_path_norm"]], "Ctrl+Shift+/")
+  expect_length(written, 1)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - removes shortcut when NULL value passed", {
+  tmp <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) TRUE,
+    rstudio_config_path = function(x) file.path(tmp, x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) "y",
+    .package = "base"
+  )
+
+  # Establish an existing shortcut
+  fs::dir_create(file.path(tmp, "keybindings"))
+  jsonlite::write_json(
+    list("make_path_norm" = "Ctrl+Shift+/"),
+    file.path(tmp, "keybindings/addins.json"),
+    auto_unbox = TRUE
+  )
+
+  # Remove the shortcut
+  suppressMessages(
+    result <- use_rstudio_keyboard_shortcut(
+      "Ctrl+Shift+/" = NULL
+    )
+  )
+
+  expect_null(result)
+  written <- jsonlite::fromJSON(file.path(tmp, "keybindings/addins.json"))
+  expect_false("make_path_norm" %in% names(written))
+  expect_length(written, 0)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - reassigning function removes old key binding", {
+  tmp <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) TRUE,
+    rstudio_config_path = function(x) file.path(tmp, x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) "y",
+    .package = "base"
+  )
+
+  # Establish an existing shortcut
+  fs::dir_create(file.path(tmp, "keybindings"))
+  jsonlite::write_json(
+    list("make_path_norm" = "Ctrl+Shift+/"),
+    file.path(tmp, "keybindings/addins.json"),
+    auto_unbox = TRUE
+  )
+
+  # Reassign same function to a new key
+  result <- suppressMessages(
+    use_rstudio_keyboard_shortcut(
+      "Ctrl+Shift+K" = "make_path_norm"
+    )
+  )
+
+  expect_null(result)
+  written <- jsonlite::fromJSON(file.path(tmp, "keybindings/addins.json"))
+  expect_equal(written[["make_path_norm"]], "Ctrl+Shift+K")
+  expect_false("Ctrl+Shift+/" %in% unlist(written))
+  expect_length(written, 1)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - reassigning key removes old function binding", {
+  tmp <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) TRUE,
+    rstudio_config_path = function(x) file.path(tmp, x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) "y",
+    .package = "base"
+  )
+
+  # Establish an existing shortcut
+  fs::dir_create(file.path(tmp, "keybindings"))
+  jsonlite::write_json(
+    list("make_path_norm" = "Ctrl+Shift+/"),
+    file.path(tmp, "keybindings/addins.json"),
+    auto_unbox = TRUE
+  )
+
+  # Reassign same key to a new function
+  result <- suppressMessages(
+    use_rstudio_keyboard_shortcut(
+      "Ctrl+Shift+/" = "print"
+    )
+  )
+
+  expect_null(result)
+  written <- jsonlite::fromJSON(file.path(tmp, "keybindings/addins.json"))
+  expect_equal(written[["print"]], "Ctrl+Shift+/")
+  expect_false("make_path_norm" %in% names(written))
+  expect_length(written, 1)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - re-adding same shortcut does not change binding", {
+  tmp <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    # no mock of pretty_print_updates in this test
+    rstudio_config_path = function(x) file.path(tmp, x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) stop("readline should not be called"),  # <-- errors if prompted
+    .package = "base"
+  )
+
+  # Establish an existing shortcut
+  fs::dir_create(file.path(tmp, "keybindings"))
+  jsonlite::write_json(
+    list("make_path_norm" = "Ctrl+Shift+/"),
+    file.path(tmp, "keybindings/addins.json"),
+    auto_unbox = TRUE
+  )
+
+  # Re-add same binding - should run without prompting user
+  capture.output(
+    suppressMessages(
+      result <- use_rstudio_keyboard_shortcut(
+        "Ctrl+Shift+/" = "make_path_norm"
+      )
+    )
+  )
+
+  expect_null(result)
+  written <- jsonlite::fromJSON(file.path(tmp, "keybindings/addins.json"))
+  expect_equal(written[["make_path_norm"]], "Ctrl+Shift+/")
+  expect_length(written, 1)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - adding multiple shortcuts in one call", {
+  tmp <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) TRUE,
+    rstudio_config_path = function(x) file.path(tmp, x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) "y",
+    .package = "base"
+  )
+
+  # Add multiple shortcuts in one call
+  suppressMessages(
+    result <- use_rstudio_keyboard_shortcut(
+      "Ctrl+Shift+/" = "make_path_norm",
+      "Ctrl+/" = "print",
+      .write_json = FALSE
+    )
+  )
+
+  expect_equal(result[["make_path_norm"]], "Ctrl+Shift+/")
+  expect_equal(result[["print"]], "Ctrl+/")
+  expect_length(result, 2)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - removing multiple shortcuts in one call", {
+  tmp <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) TRUE,
+    rstudio_config_path = function(x) file.path(tmp, x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) "y",
+    .package = "base"
+  )
+
+  # Establish existing shortcuts
+  fs::dir_create(file.path(tmp, "keybindings"))
+  jsonlite::write_json(
+    list("make_path_norm" = "Ctrl+Shift+/", "print" = "Ctrl+/"),
+    file.path(tmp, "keybindings/addins.json"),
+    auto_unbox = TRUE
+  )
+
+  # Remove multiple shortcuts in one call
+  suppressMessages(
+    result <- use_rstudio_keyboard_shortcut(
+      "Ctrl+Shift+/" = NULL,
+      "Ctrl+/" = NULL,
+      .write_json = FALSE
+    )
+  )
+
+  expect_length(result, 0)
+})
+
+test_that("use_rstudio_keyboard_shortcut() - adding and removing shortcuts in one call", {
+  tmp <- withr::local_tempdir()
+
+  local_mocked_bindings(
+    check_min_rstudio_version = function(...) invisible(NULL),
+    pretty_print_updates = function(...) TRUE,
+    rstudio_config_path = function(x) file.path(tmp, x)
+  )
+
+  local_mocked_bindings(
+    interactive = function() TRUE,
+    readline = function(prompt) "y",
+    .package = "base"
+  )
+
+  # Establish an existing shortcut
+  fs::dir_create(file.path(tmp, "keybindings"))
+  jsonlite::write_json(
+    list("print" = "Ctrl+/"),
+    file.path(tmp, "keybindings/addins.json"),
+    auto_unbox = TRUE
+  )
+
+  # Add one shortcut and remove another in one call
+  suppressMessages(
+    result <- use_rstudio_keyboard_shortcut(
+      "Ctrl+Shift+/" = "make_path_norm",
+      "Ctrl+/" = NULL
+    )
+  )
+
+  expect_null(result)
+  written <- jsonlite::fromJSON(file.path(tmp, "keybindings/addins.json"))
+  expect_equal(written[["make_path_norm"]], "Ctrl+Shift+/")
+  expect_false("print" %in% names(written))
+  expect_length(written, 1)
+})
+
+
+# check_shortcut_consistency() -------------------------------------------------
+
+test_that("check_shortcut_consistency() - unnamed list", {
   expect_error(
-    list(test = "not_a_fun") %>% check_shortcut_consistency()
+    as.list(letters) %>% check_shortcut_consistency(),
+    "must be named"
+  )
+})
+
+test_that("check_shortcut_consistency() - non-string, non-NULL value", {
+  expect_error(
+    list(test = 5) %>% check_shortcut_consistency(),
+    "must be a string"
+  )
+})
+
+test_that("check_shortcut_consistency() - valid named function string", {
+  expect_no_error(
+    list(test = "make_path_norm") %>% check_shortcut_consistency()
+  )
+})
+
+test_that("check_shortcut_consistency() - non-function string", {
+  expect_error(
+    list(test = "not_a_fun") %>% check_shortcut_consistency(),
+    "string of a function name"
+  )
+})
+
+test_that("check_shortcut_consistency() - non-function string that is a variable", {
+  expect_error(
+    list(test = "pi") %>% check_shortcut_consistency(),
+    "string of a function name"
+  )
+})
+
+test_that("check_shortcut_consistency() - NULL is allowed, explicit removal", {
+  expect_no_error(
+    list(test = NULL) %>% check_shortcut_consistency()
+  )
+})
+
+test_that("check_shortcut_consistency() - mixed valid, NULL alongside valid shortcut", {
+  expect_no_error(
+    list(a = "make_path_norm", b = NULL) %>% check_shortcut_consistency()
   )
 })


### PR DESCRIPTION
* Updates `@return` documentation for `use_rstudio_prefs()`, `use_rstudio_secondary_repo()` and `use_rstudio_keyboard_shortcut()`. Supersedes #19 and addresses both follow-up requests made by @ddsjoberg.
* Fixes issue #20 by updating the URL in `fetch_rstudio_prefs()` and documentation to https://docs.posit.co/ide/server-pro/admin/reference/session_user_settings.html.
* Addresses three issues from #22: `.1` corruption bug when reassigning a shortcut to a function that already had one, `purrr::update_list()` deprecation (replaced with base R `modifyList()`) and shortcut removal (passing `NULL` as a value now removes the binding).
* Updates tests for `use_rstudio_keyboard_shortcut()` and `check_shortcut_consistency()`.
* Test coverage revealed that `check_shortcut_consistency()` would error before reaching the abort line when passed a non-existent name, because `eval(rlang::parse_expr(.))` throws an error. Fixed by wrapping in `tryCatch`.

